### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/thomasvincent/chef-httpd-cookbook/security/code-scanning/4](https://github.com/thomasvincent/chef-httpd-cookbook/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the actions used in the workflow, the following permissions are sufficient:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.

This change will ensure that the workflow operates with the least privileges necessary, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
